### PR TITLE
Fixed bug where source node is labeled as intermediate

### DIFF
--- a/client/src/tools/Parser.jsx
+++ b/client/src/tools/Parser.jsx
@@ -14,8 +14,8 @@ export function NetworkParser(data, source, go_term) {
             },
           };
           if (
-            value[4][j].properties.name === source ||
-            value[4][j].properties.id === source
+            value[4][j].properties.name.toUpperCase() === source.toUpperCase() ||
+            value[4][j].properties.id.toUpperCase() === source.toUpperCase()
           ) {
             nodeEntry.data.type = "source";
           } else if (j == value[4].length - 2) {


### PR DESCRIPTION
Happens when case sensitivity is not ignored when checking the query source protein and node's ID or label