### PR TITLE
limit the autosuggestion dropdown

### DIFF
--- a/client/src/components/Autocomplete.jsx
+++ b/client/src/components/Autocomplete.jsx
@@ -20,7 +20,7 @@ export default function Autocomplete(props) {
             });
 
         setActive(0);
-        setFiltered(newFilteredSuggestions);
+        setFiltered(newFilteredSuggestions.slice(0,25));
         setInput(inputText);
         onInputChange({ target: { name: inputName, value: inputText } });
     };


### PR DESCRIPTION
there is a noticable lag when you type the first few letters in the search box. this was because we were not limiting the amount of suggestions that would populate in the dropdown.