### PR TITLE
Fix interaction in ancestor/descendant selectors

### DIFF
--- a/client/src/components/AncestorSelector.jsx
+++ b/client/src/components/AncestorSelector.jsx
@@ -1,12 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 
-export default function AncestorSelector({
-    parentGoTerms,
-    storeGoTermValue
-}) {
+export default function AncestorSelector({ parentGoTerms, storeGoTermValue }) {
     const [isEmpty, setIsEmpty] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
+    const [inputValue, setInputValue] = useState("");
 
     // Function to populate datalist with options from the dynamic array
     function populateDatalistWithOptions(array) {
@@ -20,7 +18,7 @@ export default function AncestorSelector({
         } else {
             setIsEmpty(false);
             // Iterate through the array and create options
-            array.forEach(optionText => {
+            array.forEach((optionText) => {
                 const option = document.createElement("option");
                 option.value = optionText;
                 datalist.appendChild(option);
@@ -33,6 +31,16 @@ export default function AncestorSelector({
     }, [parentGoTerms]);
     // Call the function to populate the datalist
 
+    const onChange = (e) => {
+        const inputText = e.currentTarget.value;
+        setInputValue(inputText);
+        storeGoTermValue(e);
+    };
+
+    const handleBlur = () => {
+        setInputValue("");
+    };
+
     return (
         <div className="ancestor-input">
             <div className="hierarchy-input-container">
@@ -44,7 +52,11 @@ export default function AncestorSelector({
                         onMouseLeave={() => setShowTooltip(false)}
                     >
                         <FaInfoCircle className="info-icon" />
-                        {showTooltip && <div className="hierarchy-warning">You have reached the most general GO term.</div>}
+                        {showTooltip && (
+                            <div className="hierarchy-warning">
+                                You have reached the most general GO term.
+                            </div>
+                        )}
                     </div>
                 )}
                 {/* normal input display */}
@@ -52,12 +64,13 @@ export default function AncestorSelector({
                     list="parent-go-terms"
                     id="ancestor-selector"
                     name="ancestor-selector"
-                    onChange={storeGoTermValue}
-                    placeholder='Parent GO Terms'
+                    onChange={onChange}
+                    placeholder="Parent GO Terms"
+                    value={inputValue}
+                    onBlur={handleBlur}
                 />
-
             </div>
             <datalist id="parent-go-terms"></datalist>
         </div>
-    )
+    );
 }

--- a/client/src/components/AncestorSelector.jsx
+++ b/client/src/components/AncestorSelector.jsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 
-export default function AncestorSelector({ parentGoTerms, storeGoTermValue }) {
+export default function AncestorSelector({
+    parentGoTerms,
+    storeGoTermValue,
+    handleInputChangeAncestor,
+    inputValueAncestor,
+}) {
     const [isEmpty, setIsEmpty] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
-    const [inputValue, setInputValue] = useState("");
 
     // Function to populate datalist with options from the dynamic array
     function populateDatalistWithOptions(array) {
@@ -33,12 +37,8 @@ export default function AncestorSelector({ parentGoTerms, storeGoTermValue }) {
 
     const onChange = (e) => {
         const inputText = e.currentTarget.value;
-        setInputValue(inputText);
+        handleInputChangeAncestor(inputText);
         storeGoTermValue(e);
-    };
-
-    const handleBlur = () => {
-        setInputValue("");
     };
 
     return (
@@ -66,8 +66,7 @@ export default function AncestorSelector({ parentGoTerms, storeGoTermValue }) {
                     name="ancestor-selector"
                     onChange={onChange}
                     placeholder="Parent GO Terms"
-                    value={inputValue}
-                    onBlur={handleBlur}
+                    value={inputValueAncestor}
                 />
             </div>
             <datalist id="parent-go-terms"></datalist>

--- a/client/src/components/DescendantSelector.jsx
+++ b/client/src/components/DescendantSelector.jsx
@@ -4,10 +4,11 @@ import { FaInfoCircle } from "react-icons/fa";
 export default function DescendantSelector({
     childrenGoTerms,
     storeGoTermValue,
+    handleInputChangeDescendant,
+    inputValueDescendant,
 }) {
     const [isEmpty, setIsEmpty] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
-    const [inputValue, setInputValue] = useState("");
 
     // Function to populate datalist with options from the dynamic array
     function populateDatalistWithOptions(array) {
@@ -36,12 +37,8 @@ export default function DescendantSelector({
 
     const onChange = (e) => {
         const inputText = e.currentTarget.value;
-        setInputValue(inputText);
+        handleInputChangeDescendant(inputText);
         storeGoTermValue(e);
-    };
-
-    const handleBlur = () => {
-        setInputValue("");
     };
 
     return (
@@ -69,8 +66,7 @@ export default function DescendantSelector({
                     name="descendant-selector"
                     onChange={onChange}
                     placeholder="Child GO Terms"
-                    value={inputValue}
-                    onBlur={handleBlur}
+                    value={inputValueDescendant}
                 />
             </div>
             <datalist id="child-go-terms"></datalist>

--- a/client/src/components/DescendantSelector.jsx
+++ b/client/src/components/DescendantSelector.jsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 
 export default function DescendantSelector({
     childrenGoTerms,
-    storeGoTermValue
+    storeGoTermValue,
 }) {
     const [isEmpty, setIsEmpty] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
+    const [inputValue, setInputValue] = useState("");
 
     // Function to populate datalist with options from the dynamic array
     function populateDatalistWithOptions(array) {
@@ -20,7 +21,7 @@ export default function DescendantSelector({
         } else {
             setIsEmpty(false);
             // Iterate through the array and create options
-            array.forEach(optionText => {
+            array.forEach((optionText) => {
                 const option = document.createElement("option");
                 option.value = optionText;
                 datalist.appendChild(option);
@@ -33,6 +34,16 @@ export default function DescendantSelector({
         populateDatalistWithOptions(childrenGoTerms);
     }, [childrenGoTerms]);
 
+    const onChange = (e) => {
+        const inputText = e.currentTarget.value;
+        setInputValue(inputText);
+        storeGoTermValue(e);
+    };
+
+    const handleBlur = () => {
+        setInputValue("");
+    };
+
     return (
         <div className="descendant-input">
             <div className="hierarchy-input-container">
@@ -44,7 +55,11 @@ export default function DescendantSelector({
                         onMouseLeave={() => setShowTooltip(false)}
                     >
                         <FaInfoCircle className="info-icon" />
-                        {showTooltip && <div className="hierarchy-warning">You have reached the most specific GO term.</div>}
+                        {showTooltip && (
+                            <div className="hierarchy-warning">
+                                You have reached the most specific GO term.
+                            </div>
+                        )}
                     </div>
                 )}
                 {/* normal input display */}
@@ -52,11 +67,13 @@ export default function DescendantSelector({
                     list="child-go-terms"
                     id="descendant-selector"
                     name="descendant-selector"
-                    onChange={storeGoTermValue}
-                    placeholder='Child GO Terms'
+                    onChange={onChange}
+                    placeholder="Child GO Terms"
+                    value={inputValue}
+                    onBlur={handleBlur}
                 />
             </div>
             <datalist id="child-go-terms"></datalist>
         </div>
-    )
+    );
 }

--- a/client/src/components/GraphExploration.jsx
+++ b/client/src/components/GraphExploration.jsx
@@ -21,8 +21,12 @@ export default function GraphExploration({
     const [proteinCount, setProteinCount] = useState(0);
     const [inputValueAncestor, setInputValueAncestor] = useState("");
     const [inputValueDescendant, setInputValueDescendant] = useState("");
-    const [goButtonClassname, setGoButtonClassname] =
-        useState("new-go-term-button");
+    const [goButtonClassname, setGoButtonClassname] = useState(
+        "new-go-term-button-disabled"
+    );
+    const [sourceNodeButton, setSourceNodeButton] = useState(
+        "new-source-disabled"
+    );
 
     // Keep track of the proteins in the query
     useEffect(() => {
@@ -87,145 +91,89 @@ export default function GraphExploration({
         handleGoTermChange();
     };
 
-    if (currentNode) {
-        // If a protein is selected, allow the user to set as source node
-        return (
-            <div>
-                <h4 className="graph-exploration-title">
-                    Graph Exploration Tools
-                </h4>
-                <div className="graph-exploration">
-                    {/* New Source Node Button */}
-                    <div className="new-source-container">
+    useEffect(() => {
+        if (currentNode) {
+            setSourceNodeButton("new-source");
+        } else {
+            setSourceNodeButton("new-source-disabled");
+        }
+    }, [currentNode]);
+    return (
+        <div>
+            <h4 className="graph-exploration-title">Graph Exploration Tools</h4>
+            <div className="graph-exploration">
+                {/* New Source Node Button */}
+                <div className="new-source-container">
+                    {currentNode && (
                         <h5>Selected protein: {currentNode.label}</h5>
-                        <form method="post" onSubmit={handleSubmit}>
+                    )}
+                    {!currentNode && <h5>Selected protein:</h5>}
+
+                    <form method="post" onSubmit={handleSubmit}>
+                        <button
+                            className={sourceNodeButton}
+                            onClick={handleSourceNode}
+                            new-source-node={
+                                currentNode && currentNode.label
+                                    ? currentNode.label
+                                    : ""
+                            }
+                            disabled={
+                                sourceNodeButton ==
+                                "new-go-term-button-disabled"
+                            }
+                        >
+                            Set as New Source Node
+                        </button>
+                    </form>
+                </div>
+                {/* GO Term Selection */}
+                <div className="go-container">
+                    <h5>Change queried GO Term:</h5>
+                    <div className="go-selector-container">
+                        <AncestorSelector
+                            parentGoTerms={parentGoTerms}
+                            storeGoTermValue={storeGoTermValue}
+                            handleInputChangeAncestor={
+                                handleInputChangeAncestor
+                            }
+                            inputValueAncestor={inputValueAncestor}
+                        />
+                        <DescendantSelector
+                            childrenGoTerms={childrenGoTerms}
+                            storeGoTermValue={storeGoTermValue}
+                            handleInputChangeDescendant={
+                                handleInputChangeDescendant
+                            }
+                            inputValueDescendant={inputValueDescendant}
+                        />
+                        <form
+                            method="post"
+                            onSubmit={handleSubmit}
+                            className="new-go-form"
+                        >
                             <button
-                                className="new-source"
-                                onClick={handleSourceNode}
-                                new-source-node={currentNode.label}
+                                className={goButtonClassname}
+                                onClick={handleNewGoButton}
+                                disabled={
+                                    goButtonClassname ==
+                                    "new-go-term-button-disabled"
+                                }
                             >
-                                Set as New Source Node
+                                Set as New GO Term
                             </button>
                         </form>
                     </div>
-                    {/* GO Term Selection */}
-                    <div className="go-container">
-                        <h5>Change queried GO Term:</h5>
-                        <div className="go-selector-container">
-                            <AncestorSelector
-                                parentGoTerms={parentGoTerms}
-                                storeGoTermValue={storeGoTermValue}
-                                handleInputChangeAncestor={
-                                    handleInputChangeAncestor
-                                }
-                                inputValueAncestor={inputValueAncestor}
-                            />
-                            <DescendantSelector
-                                childrenGoTerms={childrenGoTerms}
-                                storeGoTermValue={storeGoTermValue}
-                                handleInputChangeDescendant={
-                                    handleInputChangeDescendant
-                                }
-                                inputValueDescendant={inputValueDescendant}
-                            />
-                            <form
-                                method="post"
-                                onSubmit={handleSubmit}
-                                className="new-go-form"
-                            >
-                                <button
-                                    className={goButtonClassname}
-                                    onClick={handleNewGoButton}
-                                    disabled={
-                                        goButtonClassname ==
-                                        "new-go-term-button-disabled"
-                                    }
-                                >
-                                    Set as New GO Term
-                                </button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-                {/* Export Logs/PNG */}
-                <div className="exports-container">
-                    <h5>Export logs or PNG of current network:</h5>
-                    <ExportLogJSON log={logs} />
-                    <a className="export" onClick={exportPNG}>
-                        Export Graph to PNG
-                    </a>
                 </div>
             </div>
-        );
-    } else {
-        // If no protein is selected, do not allow the user to set as source node
-        return (
-            <div>
-                <h4 className="graph-exploration-title">
-                    Graph Exploration Tools
-                </h4>
-                <div className="graph-exploration">
-                    {/* New Source Node Button */}
-                    <div className="new-source-container">
-                        <h5>Select a protein: </h5>
-                        <form method="post" onSubmit={handleSubmit}>
-                            <button
-                                className="new-source-disabled"
-                                onClick={handleSourceNode}
-                                disabled={true}
-                            >
-                                Set as New Source Node
-                            </button>
-                        </form>
-                    </div>
-                    {/* GO Term Selection */}
-                    <div className="go-container">
-                        <h5>Change queried GO Term:</h5>
-                        <div className="go-selector-container">
-                            <AncestorSelector
-                                parentGoTerms={parentGoTerms}
-                                storeGoTermValue={storeGoTermValue}
-                                handleInputChangeAncestor={
-                                    handleInputChangeAncestor
-                                }
-                                inputValueAncestor={inputValueAncestor}
-                            />
-                            <DescendantSelector
-                                childrenGoTerms={childrenGoTerms}
-                                storeGoTermValue={storeGoTermValue}
-                                handleInputChangeDescendant={
-                                    handleInputChangeDescendant
-                                }
-                                inputValueDescendant={inputValueDescendant}
-                            />
-                            <form
-                                method="post"
-                                onSubmit={handleSubmit}
-                                className="new-go-form"
-                            >
-                                <button
-                                    className={goButtonClassname}
-                                    onClick={handleNewGoButton}
-                                    disabled={
-                                        goButtonClassname ==
-                                        "new-go-term-button-disabled"
-                                    }
-                                >
-                                    Set as New GO Term
-                                </button>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-                {/* Export Logs/PNG */}
-                <div className="exports-container">
-                    <h5>Export logs or PNG of current network:</h5>
-                    <ExportLogJSON log={logs} />
-                    <a className="export" onClick={exportPNG}>
-                        Export Graph to PNG
-                    </a>
-                </div>
+            {/* Export Logs/PNG */}
+            <div className="exports-container">
+                <h5>Export logs or PNG of current network:</h5>
+                <ExportLogJSON log={logs} />
+                <a className="export" onClick={exportPNG}>
+                    Export Graph to PNG
+                </a>
             </div>
-        );
-    }
+        </div>
+    );
 }

--- a/client/src/components/GraphExploration.jsx
+++ b/client/src/components/GraphExploration.jsx
@@ -19,6 +19,10 @@ export default function GraphExploration({
     handleGoTermChange,
 }) {
     const [proteinCount, setProteinCount] = useState(0);
+    const [inputValueAncestor, setInputValueAncestor] = useState("");
+    const [inputValueDescendant, setInputValueDescendant] = useState("");
+    const [goButtonClassname, setGoButtonClassname] =
+        useState("new-go-term-button");
 
     // Keep track of the proteins in the query
     useEffect(() => {
@@ -33,7 +37,6 @@ export default function GraphExploration({
         }
     }, [currentNode]);
 
-
     // Keep track of the queries
     useEffect(() => {
         if (query) {
@@ -45,11 +48,52 @@ export default function GraphExploration({
             handleLog(newQuery);
         }
     }, [searchExecuted]);
+
+    const handleInputChangeAncestor = (value) => {
+        setInputValueAncestor(value);
+    };
+
+    const handleInputChangeDescendant = (value) => {
+        setInputValueDescendant(value);
+    };
+
+    useEffect(() => {
+        if (inputValueAncestor == "" && inputValueDescendant == "") {
+            setGoButtonClassname("new-go-term-button-disabled");
+        } else if (inputValueAncestor != "" || inputValueDescendant != "") {
+            setGoButtonClassname("new-go-term-button");
+        }
+    }, [inputValueAncestor, inputValueDescendant]);
+
+    useEffect(() => {
+        if (inputValueAncestor != "") {
+            setInputValueDescendant("");
+        } else {
+            setInputValueAncestor("");
+        }
+    }, [inputValueAncestor]);
+
+    useEffect(() => {
+        if (inputValueDescendant != "") {
+            setInputValueAncestor("");
+        } else {
+            setInputValueDescendant("");
+        }
+    }, [inputValueDescendant]);
+
+    const handleNewGoButton = () => {
+        setInputValueAncestor("");
+        setInputValueDescendant("");
+        handleGoTermChange();
+    };
+
     if (currentNode) {
         // If a protein is selected, allow the user to set as source node
         return (
             <div>
-                <h4 className="graph-exploration-title">Graph Exploration Tools</h4>
+                <h4 className="graph-exploration-title">
+                    Graph Exploration Tools
+                </h4>
                 <div className="graph-exploration">
                     {/* New Source Node Button */}
                     <div className="new-source-container">
@@ -71,15 +115,31 @@ export default function GraphExploration({
                             <AncestorSelector
                                 parentGoTerms={parentGoTerms}
                                 storeGoTermValue={storeGoTermValue}
+                                handleInputChangeAncestor={
+                                    handleInputChangeAncestor
+                                }
+                                inputValueAncestor={inputValueAncestor}
                             />
                             <DescendantSelector
                                 childrenGoTerms={childrenGoTerms}
                                 storeGoTermValue={storeGoTermValue}
+                                handleInputChangeDescendant={
+                                    handleInputChangeDescendant
+                                }
+                                inputValueDescendant={inputValueDescendant}
                             />
-                            <form method="post" onSubmit={handleSubmit} className="new-go-form">
+                            <form
+                                method="post"
+                                onSubmit={handleSubmit}
+                                className="new-go-form"
+                            >
                                 <button
-                                    className="new-go-term-button"
-                                    onClick={handleGoTermChange}
+                                    className={goButtonClassname}
+                                    onClick={handleNewGoButton}
+                                    disabled={
+                                        goButtonClassname ==
+                                        "new-go-term-button-disabled"
+                                    }
                                 >
                                     Set as New GO Term
                                 </button>
@@ -96,13 +156,14 @@ export default function GraphExploration({
                     </a>
                 </div>
             </div>
-
-        )
+        );
     } else {
         // If no protein is selected, do not allow the user to set as source node
         return (
             <div>
-                <h4 className="graph-exploration-title">Graph Exploration Tools</h4>
+                <h4 className="graph-exploration-title">
+                    Graph Exploration Tools
+                </h4>
                 <div className="graph-exploration">
                     {/* New Source Node Button */}
                     <div className="new-source-container">
@@ -124,15 +185,31 @@ export default function GraphExploration({
                             <AncestorSelector
                                 parentGoTerms={parentGoTerms}
                                 storeGoTermValue={storeGoTermValue}
+                                handleInputChangeAncestor={
+                                    handleInputChangeAncestor
+                                }
+                                inputValueAncestor={inputValueAncestor}
                             />
                             <DescendantSelector
                                 childrenGoTerms={childrenGoTerms}
                                 storeGoTermValue={storeGoTermValue}
+                                handleInputChangeDescendant={
+                                    handleInputChangeDescendant
+                                }
+                                inputValueDescendant={inputValueDescendant}
                             />
-                            <form method="post" onSubmit={handleSubmit} className="new-go-form">
+                            <form
+                                method="post"
+                                onSubmit={handleSubmit}
+                                className="new-go-form"
+                            >
                                 <button
-                                    className="new-go-term-button"
-                                    onClick={handleGoTermChange}
+                                    className={goButtonClassname}
+                                    onClick={handleNewGoButton}
+                                    disabled={
+                                        goButtonClassname ==
+                                        "new-go-term-button-disabled"
+                                    }
                                 >
                                     Set as New GO Term
                                 </button>
@@ -149,6 +226,6 @@ export default function GraphExploration({
                     </a>
                 </div>
             </div>
-        )
+        );
     }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -521,6 +521,20 @@ select {
   text-align: center;
 }
 
+.new-go-term-button-disabled {
+  display: inline-block;
+  margin-left: 36px;
+  min-height: 50px;
+  min-width: 200px;
+  word-wrap: nowrap;
+  background: #888888;
+  color: #fff;
+  border: 2px solid var(--light-background);
+  border-radius: 5px;
+  text-align: center;
+  cursor: auto;
+}
+
 .exports-container {
   text-align: center;
   flex: 1;


### PR DESCRIPTION
Previously, if users typed something in the ancestor/descendant go term exploration inputs, they will have to delete the input fields before further traversing. this adds an unnecessary step in the user experience.

- the input fields for the go term exploration now are cleared when the user click out of the input field or if they click the set new go term box 