### PR TITLE
fixed parser bug

### DIFF
--- a/client/src/components/Query.jsx
+++ b/client/src/components/Query.jsx
@@ -235,7 +235,7 @@ export default function Query() {
         let rawData = null;
         if (query.mode == "path") {
             try {
-                network = await fetch("/api/getQuery", {
+                network = await fetch("/api/getQueryByPath", {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
@@ -259,11 +259,7 @@ export default function Query() {
                     })
                     .then((data) => {
                         rawData = data;
-                        return NetworkParserPath(
-                            data,
-                            query.protein,
-                            query.goTerm
-                        );
+                        return NetworkParserPath(data);
                     });
             } catch (error) {
                 console.error("Error getting the network:", error.message);
@@ -299,7 +295,7 @@ export default function Query() {
                     })
                     .then((data) => {
                         rawData = data;
-                        return NetworkParserNode(data, query.protein, query.k);
+                        return NetworkParserNode(data, query.k);
                     });
             } catch (error) {
                 console.error("Error getting the network:", error.message);
@@ -867,14 +863,12 @@ export default function Query() {
                                                             setEdgeSource(
                                                                 evt.target
                                                                     ._private
-                                                                    .data
-                                                                    .source
+                                                                    .data.source
                                                             );
                                                             setEdgeTarget(
                                                                 evt.target
                                                                     ._private
-                                                                    .data
-                                                                    .target
+                                                                    .data.target
                                                             );
                                                             setEdgeType(
                                                                 evt.target
@@ -908,7 +902,9 @@ export default function Query() {
                                                 handleSourceNode={
                                                     handleSourceNode
                                                 }
-                                                handleLayoutChange={handleLayoutChange}
+                                                handleLayoutChange={
+                                                    handleLayoutChange
+                                                }
                                                 handleSubmit={handleSubmit}
                                                 parentGoTerms={ancestorsOptions}
                                                 childrenGoTerms={
@@ -947,7 +943,9 @@ export default function Query() {
                                                 queryCount={queryCount}
                                                 logs={logs}
                                                 handleLog={handleLog}
-                                                networkStatistics={networkStatistics}
+                                                networkStatistics={
+                                                    networkStatistics
+                                                }
                                             />
                                         </div>
                                     </Panel>

--- a/client/src/tools/Parser.jsx
+++ b/client/src/tools/Parser.jsx
@@ -276,4 +276,4 @@ export function NetworkParserNode(data, k) {
     }
     parsedData.goTerm = data[data.length - 1][0]._fields[0].properties;
     return parsedData;
-}
+};

--- a/client/src/tools/Parser.jsx
+++ b/client/src/tools/Parser.jsx
@@ -13,10 +13,10 @@ export function NetworkParserPath(data) {
             // handles the case where name param doesnt exist. representing node that only has regulatory interactions
             if (currentPath[j].properties.name != null) {
                 nodeName = currentPath[j].properties.name;
-            } else if (currentPath[j].properties.alt_name != null) {
-                nodeName = currentPath[j].properties.alt_name;
             } else if (currentPath[j].properties.gene_name != null) {
                 nodeName = currentPath[j].properties.gene_name;
+            } else if (currentPath[j].properties.alt_name != null) {
+                nodeName = currentPath[j].properties.alt_name;
             } else {
                 nodeName = currentPath[j].properties.id;
             }
@@ -216,10 +216,10 @@ export function NetworkParserNode(data, k) {
             // handles the case where name param doesnt exist. representing node that only has regulatory interactions
             if (currentPath[j].properties.name != null) {
                 nodeName = currentPath[j].properties.name;
-            } else if (currentPath[j].properties.alt_name != null) {
-                nodeName = currentPath[j].properties.alt_name;
             } else if (currentPath[j].properties.gene_name != null) {
                 nodeName = currentPath[j].properties.gene_name;
+            } else if (currentPath[j].properties.alt_name != null) {
+                nodeName = currentPath[j].properties.alt_name;
             } else {
                 nodeName = currentPath[j].properties.id;
             }

--- a/client/src/tools/Parser.jsx
+++ b/client/src/tools/Parser.jsx
@@ -237,13 +237,13 @@ export function NetworkParserNode(data, k) {
                 },
             };
             if (
-                nodeId.toUpperCase() == sourceId.toUpperCase() &&
-                j == currentPath.length - 2
+                nodeId.toUpperCase() === sourceId.toUpperCase() &&
+                j == currentPath.length - 1
             ) {
                 nodeEntry.data.type = "go_source";
-            } else if (nodeId.toUpperCase() == sourceId.toUpperCase()) {
+            } else if (nodeId.toUpperCase() === sourceId.toUpperCase()) {
                 nodeEntry.data.type = "source";
-            } else if (j == currentPath.length - 2) {
+            } else if (j == currentPath.length - 1) {
                 nodeEntry.data.type = "go_protein";
             } else {
                 nodeEntry.data.type = "intermediate";

--- a/client/src/tools/Parser.jsx
+++ b/client/src/tools/Parser.jsx
@@ -1,20 +1,31 @@
-export function NetworkParserPath(data, source, go_term) {
+export function NetworkParserPath(data) {
     let parsedData = { nodes: [], edges: [], nodeList: [], edgeList: [] };
     //Iterate through data where each element is a path
     for (let i = 0; i < data.length; i++) {
         let currentPath = data[i]._fields[4];
         let startNode = null;
         let endNode = null;
+        let sourceId = null;
         for (let j = 0; j < currentPath.length - 1; j++) {
             let nodeName = null;
             let nodeId = currentPath[j].properties.id;
-            let nodeAltName = currentPath[j].properties.alt_name;
+
             // handles the case where name param doesnt exist. representing node that only has regulatory interactions
             if (currentPath[j].properties.name != null) {
                 nodeName = currentPath[j].properties.name;
-            } else {
+            } else if (currentPath[j].properties.alt_name != null) {
+                nodeName = currentPath[j].properties.alt_name;
+            } else if (currentPath[j].properties.gene_name != null) {
                 nodeName = currentPath[j].properties.gene_name;
+            } else {
+                nodeName = currentPath[j].properties.id;
             }
+
+            // source protein is always the first element
+            if (j == 0) {
+                sourceId = currentPath[j].properties.id;
+            }
+
             //Add each node in a path, and label them accordingly (source, go_protein, or intermediate)
             //Keep track of all the nodes in nodeList
             let nodeEntry = {
@@ -25,17 +36,11 @@ export function NetworkParserPath(data, source, go_term) {
                 },
             };
             if (
-                (nodeName.toUpperCase() === source.toUpperCase() ||
-                    nodeId.toUpperCase() === source.toUpperCase() ||
-                    nodeAltName.toUpperCase() === source.toUpperCase()) &&
+                nodeId.toUpperCase() == sourceId.toUpperCase() &&
                 j == currentPath.length - 2
             ) {
                 nodeEntry.data.type = "go_source";
-            } else if (
-                nodeName.toUpperCase() === source.toUpperCase() ||
-                nodeId.toUpperCase() === source.toUpperCase() ||
-                nodeAltName.toUpperCase() === source.toUpperCase()
-            ) {
+            } else if (nodeId.toUpperCase() == sourceId.toUpperCase()) {
                 nodeEntry.data.type = "source";
             } else if (j == currentPath.length - 2) {
                 nodeEntry.data.type = "go_protein";
@@ -58,7 +63,7 @@ export function NetworkParserPath(data, source, go_term) {
                 let edgeEntry = {
                     data: {
                         source: endNode,
-                        target: startNode
+                        target: startNode,
                     },
                 };
                 parsedData.edgeList.push(startNode + endNode);
@@ -83,16 +88,19 @@ export function NetworkParserPath(data, source, go_term) {
 // tag::EdgeDataParser
 export function EdgeDataParser(networkData, edgeData) {
     //Iterate through al the edges in the induced subgraph
-    // console.log(edgeData)
     let tempEdgeList = [];
     let tempEdges = [];
     for (let i = 0; i < edgeData.length; i++) {
         let startNode = edgeData[i]._fields[0].start.properties.id;
         let endNode = edgeData[i]._fields[0].end.properties.id;
         let relType = edgeData[i]._fields[0].segments[0].relationship.type;
-        let pubmed = edgeData[i]._fields[0].segments[0].relationship.properties.pubmed;
-        let link = edgeData[i]._fields[0].segments[0].relationship.properties.link;
-        let fbRef = edgeData[i]._fields[0].segments[0].relationship.properties.reference;
+        let pubmed =
+            edgeData[i]._fields[0].segments[0].relationship.properties.pubmed;
+        let link =
+            edgeData[i]._fields[0].segments[0].relationship.properties.link;
+        let fbRef =
+            edgeData[i]._fields[0].segments[0].relationship.properties
+                .reference;
         //Check for shared edges
         //If the edge already exists in the initial network data, add it to the temp edge list
         if (
@@ -111,8 +119,7 @@ export function EdgeDataParser(networkData, edgeData) {
                     };
                     tempEdgeList.push(startNode + endNode);
                     tempEdges.push(edgeEntry);
-                }
-                else if (link) {
+                } else if (link) {
                     let edgeEntry = {
                         data: {
                             source: endNode,
@@ -123,8 +130,7 @@ export function EdgeDataParser(networkData, edgeData) {
                     };
                     tempEdgeList.push(startNode + endNode);
                     tempEdges.push(edgeEntry);
-                }
-                else if (fbRef) {
+                } else if (fbRef) {
                     let edgeEntry = {
                         data: {
                             source: endNode,
@@ -139,9 +145,7 @@ export function EdgeDataParser(networkData, edgeData) {
             }
         }
         //If the edge type is ProGo, add the edges relationship properties to the network data
-        else if (
-            relType === "ProGo"
-        ) {
+        else if (relType === "ProGo") {
             for (let k = 0; k < networkData.nodes.length; k++) {
                 let currentNode = networkData.nodes[k];
                 if (currentNode.data.id === startNode) {
@@ -197,22 +201,34 @@ export function EdgeDataParser(networkData, edgeData) {
     networkData.edges = tempEdges;
     return networkData;
 }
-export function NetworkParserNode(data, source, k) {
+export function NetworkParserNode(data, k) {
     let parsedData = { nodes: [], edges: [], nodeList: [], edgeList: [] };
     for (let i = 0; i < Math.min(k, data.length - 1); i++) {
         let currentPath = data[i];
+        let sourceId = null;
         for (let j = 0; j < currentPath.length; j++) {
             //Add each node in a path, and label them accordingly (source, go_protein, or intermediate)
             //Keep track of all the nodes in nodeList
+            //If the edge already exists in the initial network data, add it to the temp edge list\
             let nodeName = null;
             let nodeId = currentPath[j].properties.id;
-            let nodeAltName = currentPath[j].properties.alt_name;
-            //If the edge already exists in the initial network data, add it to the temp edge list\
+
+            // handles the case where name param doesnt exist. representing node that only has regulatory interactions
             if (currentPath[j].properties.name != null) {
                 nodeName = currentPath[j].properties.name;
-            } else {
+            } else if (currentPath[j].properties.alt_name != null) {
+                nodeName = currentPath[j].properties.alt_name;
+            } else if (currentPath[j].properties.gene_name != null) {
                 nodeName = currentPath[j].properties.gene_name;
+            } else {
+                nodeName = currentPath[j].properties.id;
             }
+
+            // source protein is always the first element
+            if (j == 0) {
+                sourceId = currentPath[j].properties.id;
+            }
+
             let nodeEntry = {
                 data: {
                     id: nodeId,
@@ -221,17 +237,13 @@ export function NetworkParserNode(data, source, k) {
                 },
             };
             if (
-                (nodeId.toUpperCase() === source.toUpperCase()) &&
-                j == currentPath.length - 1
+                nodeId.toUpperCase() == sourceId.toUpperCase() &&
+                j == currentPath.length - 2
             ) {
                 nodeEntry.data.type = "go_source";
-            } else if (
-                nodeName.toUpperCase() === source.toUpperCase() ||
-                nodeId.toUpperCase() === source.toUpperCase() ||
-                nodeAltName.toUpperCase() === source.toUpperCase()
-            ) {
+            } else if (nodeId.toUpperCase() == sourceId.toUpperCase()) {
                 nodeEntry.data.type = "source";
-            } else if (j == currentPath.length - 1) {
+            } else if (j == currentPath.length - 2) {
                 nodeEntry.data.type = "go_protein";
             } else {
                 nodeEntry.data.type = "intermediate";

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -249,7 +249,7 @@ router.post("/getQueryByPath", jsonParser, async (req, res, next) => {
       }
     }
   } catch (error) {
-    console.error("Error in /getQuery:", error);
+    console.error("Error in /getQueryByPath:", error);
     res.status(500).json({ error: "Internal server error." });
   }
 });

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -178,7 +178,7 @@ router.post("/Motif", jsonParser, async (req, res, next) => {
 });
 
 // dynamic query
-router.post("/getQuery", jsonParser, async (req, res, next) => {
+router.post("/getQueryByPath", jsonParser, async (req, res, next) => {
   const data = req.body;
   const species = data.species;
   const protein = data.protein.replace(/[^a-zA-Z0-9\s]/g, '.');


### PR DESCRIPTION
- Fixed bug where node properties in parser had undefined values. now label names have the following hierarchy related to what it chooses for the label field: Name, gene_name, alt_name, and then id as a last case
- renamed 'getQueryByPath' to follow convention